### PR TITLE
Add getQueries()

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ See [API document](https://teppeis.github.io/redash-client/)
 ### Supported REST API
 
 - `#getQuery()`
+- `#getQueries()`
 - `#postQuery()`
 - `#getJob()`
 - `#getQueryResult()`

--- a/src/RedashClient.js
+++ b/src/RedashClient.js
@@ -34,6 +34,15 @@ class RedashClient {
   }
 
   /**
+   * @param {number} id
+   * @return {Promise<Query>}
+   */
+  getQueries(id) {
+    const resource = id ? `api/queries/${id}` : `api/queries`;
+    return this.axios_.get(resource).then(resp => resp.data);
+  }
+
+  /**
    * @param {{data_source_id: number, max_age: number, query: string, query_id: number}} query
    * @return {Promise<{job: Job}|{query_result: QueryResult}>}
    */

--- a/test/index.js
+++ b/test/index.js
@@ -34,6 +34,15 @@ describe('RedashClient', () => {
       assert.deepEqual(actual, expectedBody);
     });
 
+    /** @test {RedashClient#getQueries} */
+    it('getQueries', async () => {
+      const expectedBody = require('./fixtures/get-query');
+
+      mock.onGet(`/api/queries`).reply(200, expectedBody);
+      const actual = await client.getQueries();
+      assert.deepEqual(actual, expectedBody);
+    });
+
     /** @test {RedashClient#postQuery} */
     it('postQuery with max_age = 0', async () => {
       const expectedBody = require('./fixtures/post-query_results-max_age_0');


### PR DESCRIPTION
Hi. I wanted such this npm! 👍 
Add getQueries() which return all queries. And getQueries(id) is same as getQuery(id).

I think getQueries() is more easily understand than getQuery() because the resource is `api/queries/:id`.
What do you think about this? I will add rest APIs with the direction.